### PR TITLE
Allow saving an empty hotkey configuration

### DIFF
--- a/app/hotkey.html
+++ b/app/hotkey.html
@@ -139,12 +139,7 @@
 
         function saveHotkey() {
             var hotkeys = $('#all_hotkeys').val() || [];
-            if (hotkeys.length === 0) {
-                fs.unlinkSync(hotkeyPath);
-            } else {
-                
-                fs.writeFileSync(hotkeyPath, hotkeys.join(','));
-            }
+            fs.writeFileSync(hotkeyPath, hotkeys.join(','));
             closeWindow();
         }
 

--- a/app/main.js
+++ b/app/main.js
@@ -265,48 +265,52 @@ function registerHotkeys() {
     } catch (err) {
         console.log(`Error unregistering hotkeys: ${err}`)
     } 
-    var registered = false;   
-    if (fs.existsSync(hotkeyPath)) {
-        
-        var hotkeys = fs.readFileSync(hotkeyPath, {encoding: 'utf-8'}).trim();
-        if (hotkeys.indexOf(",") > -1) {
-            hotkeys = hotkeys.split(',').map(el => { return el.trim() });
+    var registered = false;
+    var hasCustomHotkeyConfig = fs.existsSync(hotkeyPath);
+    if (hasCustomHotkeyConfig) {
+        var hotkeys = fs.readFileSync(hotkeyPath, {encoding: 'utf-8'})
+            .split(',')
+            .map(el => { return el.trim() })
+            .filter(el => { return el !== '' });
+
+        if (hotkeys.length === 0) {
+            console.log('Custom hotkey config is empty, skipping hotkey registration')
+            registered = true;
         } else {
-            hotkeys = [hotkeys];
-        }
-        console.log(`Registering custom hotkeys: ${hotkeys}`)
-        var errs = hotkeys.map(hotkey => {
-            console.log(`Registering hotkey: ${hotkey}`)
-            return globalShortcut.register(hotkey, () => {
-                if (mb.window.isVisible()) {
-                    hideWindow();
-                } else {
-                    showWindow();
-                }
-                win.webContents.send('shortcutWin');
+            console.log(`Registering custom hotkeys: ${hotkeys}`)
+            var errs = hotkeys.map(hotkey => {
+                console.log(`Registering hotkey: ${hotkey}`)
+                return globalShortcut.register(hotkey, () => {
+                    if (mb.window.isVisible()) {
+                        hideWindow();
+                    } else {
+                        showWindow();
+                    }
+                    win.webContents.send('shortcutWin');
+                })
             })
-        })
-        // var ret = globalShortcut.registerAll(hotkeys, () => {
-        //     if (mb.window.isVisible()) {
-        //         hideWindow();
-        //     } else {
-        //         showWindow();
-        //     }
-        //     win.webContents.send('shortcutWin');
-        // })
-        var ret = errs.every(el => { return el });
-        if (!ret) {
-            errs.forEach((err, idx) => {
-                if (!err) {
-                    console.log(`Error registering hotkey: ${hotkeys[idx]}`)
-                }
-            })
-            console.log(`Error registering hotkeys: ${hotkeys}`)
-        } else {
-            registered =true;
+            // var ret = globalShortcut.registerAll(hotkeys, () => {
+            //     if (mb.window.isVisible()) {
+            //         hideWindow();
+            //     } else {
+            //         showWindow();
+            //     }
+            //     win.webContents.send('shortcutWin');
+            // })
+            var ret = errs.every(el => { return el });
+            if (!ret) {
+                errs.forEach((err, idx) => {
+                    if (!err) {
+                        console.log(`Error registering hotkey: ${hotkeys[idx]}`)
+                    }
+                })
+                console.log(`Error registering hotkeys: ${hotkeys}`)
+            } else {
+                registered = true;
+            }
         }
-    } 
-    if (!registered) {
+    }
+    if (!registered && !hasCustomHotkeyConfig) {
         globalShortcut.registerAll(['Super+Shift+R', 'Command+Control+R'], () => {
             if (mb.window.isVisible()) {
                 hideWindow();


### PR DESCRIPTION
## Summary

  This PR fixes hotkey persistence so users can save an empty shortcut configuration.

  Before this change, removing all shortcuts and saving would cause the app to restore the default hotkeys. The app treated a missing `hotkey.txt` file as "use defaults",
  which made it impossible to persist "no shortcut".

  ## Changes

  - write an empty `hotkey.txt` file when no hotkeys are selected
  - treat an existing but empty hotkey config as "do not register any shortcut"
  - only fall back to default hotkeys when no custom hotkey config exists at all

  ## Result

  Users can now:
  - remove all shortcuts
  - save the form with an empty value
  - keep the application without any registered global shortcut
